### PR TITLE
fix(extensions/hacker-news): close extension after triggering actions like `Open` or `View Comments`

### DIFF
--- a/src/extensions/HackerNewsExtension/HackerNewsCommandsProvider.cs
+++ b/src/extensions/HackerNewsExtension/HackerNewsCommandsProvider.cs
@@ -9,15 +9,21 @@ namespace HackerNewsExtension;
 
 public partial class HackerNewsCommandsProvider : CommandProvider
 {
+    private readonly ICommandItem[] _actions;
+
     public HackerNewsCommandsProvider()
     {
         DisplayName = "Hacker News Commands";
         Icon = HackerNewsPage.HackerNewsIcon;
-    }
 
-    private readonly ICommandItem[] _actions = [
-        new CommandItem(new HackerNewsPage()),
-    ];
+        _actions = [
+        new CommandItem(new HackerNewsPage())
+        {
+            Title = "Hacker News",
+            Subtitle = "Search & Browse posts on Hacker News",
+        },
+        ];
+    }
 
     public override ICommandItem[] TopLevelCommands() => _actions;
 }


### PR DESCRIPTION
Closes: [#6](https://github.com/zadjii/CmdPalExtensions/issues/6)

## Description

#### Before the fix:

#### After the fix:

### Question:

Currently, the behavior is to **dismiss** the Palette using `CommandResult.Dismiss()`, rather than **hide** it via `CommandResult.Hide()`.

Do you think hiding the Palette might be a better approach? Hiding would preserve the state of the Palette and keep the active extension loaded, which could improve the user experience—especially when users frequently interact with the same extension.

However, dismissing the Palette ensures consistency across all extensions, as it's the standard behavior. It’s a tradeoff between maintaining state for convenience versus following a consistent interaction pattern.
